### PR TITLE
Get pre-commit to check for large files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,2 +1,11 @@
 ci:
   autofix_prs: false
+
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+    # This will ignore files commited with git LFS, which is the correct
+    # way to add large files in this repository
+  - id: check-added-large-files
+    args: ['enforce-all', 'maxkb=10']


### PR DESCRIPTION
This makes pre-commit actually do something by checking for large files. This would catch the situation where someone forgets to add a file using git LFS e.g. if they don't have git-lfs installed.